### PR TITLE
Use gradle-josm-plugin for build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,9 @@
 plugins {
-    id "de.undercouch.download" version "3.1.1"
+    id 'org.openstreetmap.josm' version '0.2.1'
+    id 'java'
+    id 'groovy'
+    id 'eclipse'
 }
-
-apply plugin: "java"
-apply plugin: "groovy"
-apply plugin: "eclipse"
 
 def currentPluginVersion(config) {
     return config.releases.collect {it.pluginVersion}.max()
@@ -25,35 +24,38 @@ repositories {
     mavenCentral()
 }
 
-configurations {
-    rhino
-    jsyntaxpane
-    javaxvalidation
-}
-
 dependencies {
-    rhino group: "org.mozilla", name: "rhino", version: "1.7.7.1"
-    jsyntaxpane group: "de.sciss", name: "jsyntaxpane", version: "1.0.0"
-    javaxvalidation group: 'javax.validation', name: 'validation-api', version: '1.0.0.GA'
+    packIntoJar group: "org.mozilla", name: "rhino", version: "1.7.7.1"
+    packIntoJar group: "de.sciss", name: "jsyntaxpane", version: "1.0.0"
+    packIntoJar group: 'javax.validation', name: 'validation-api', version: '1.0.0.GA'
 
-    compile configurations.rhino.dependencies
-    compile configurations.jsyntaxpane.dependencies
-    compile configurations.javaxvalidation.dependencies
+    implementation group: "org.python", name: "jython", version: "2.7.0"
 
-    compile group: "org.python", name: "jython", version: "2.7.0"
-    compile files("libs/josm.jar")
-    compile group: 'junit', name: 'junit', version: '4.12'
-    compile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.4.12'
-
-    testCompile configurations.rhino.dependencies
-    testCompile configurations.jsyntaxpane.dependencies
-    testCompile configurations.javaxvalidation.dependencies
-    testCompile group: "org.python", name: "jython", version: "2.7.0"
-
-    testRuntime files("test")
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.4.12'
 }
 
-jar.baseName = "scripting"
+def ConfigObject releaseHistory = new ConfigSlurper().parse(file("releases.conf").text)
+
+version = currentPluginVersion(releaseHistory)
+archivesBaseName = "scripting"
+
+josm {
+    josmCompileVersion = 13170
+    manifest {
+        description = 'Runs scripts in JOSM'
+        minJosmVersion = currentPluginMainVersion(releaseHistory)
+        mainClass = 'org.openstreetmap.josm.plugins.scripting.ScriptingPlugin'
+        iconPath = 'images/script-engine.png'
+        website = new URL("https://gubaer.github.io/josm-scripting-plugin")
+        canLoadAtRuntime = true
+
+        releaseHistory.releases.collect{it.josmVersion}.unique().sort().each {jv ->
+            def String dv = bestPluginVersion(releaseHistory, jv)
+            oldVersionDownloadLink jv, dv, new URL("https://raw.github.com/Gubaer/josm-scripting-plugin/for-josm-${jv}/dist/scripting.jar")
+        }
+    }
+}
 
 jar {
     metaInf {
@@ -61,30 +63,6 @@ jar {
             include "mime.types"
         }
     }
-    manifest {
-        def config = new ConfigSlurper().parse(file("releases.conf").text)
-        attributes(
-            "Plugin-Date": new Date().format("yyyy-MM-dd HH:mm"),
-            "Plugin-Version": currentPluginVersion(config),
-            "Plugin-Mainversion": currentPluginMainVersion(config),
-            "Created-By": System.getProperty('java.version') + ' (' + System.getProperty('java.vendor') + ')',
-            "Built-With": "gradle-${project.getGradle().getGradleVersion()}, groovy-${GroovySystem.getVersion()}",
-            "Plugin-Class" : "org.openstreetmap.josm.plugins.scripting.ScriptingPlugin",
-            "Plugin-Description": "Runs scripts in JOSM",
-            "Plugin-Icon" : "images/script-engine.png",
-            "Plugin-Link" : "http://gubaer.github.com/josm-scripting-plugin",
-            "Plugin-Canloadatruntime" : "true"
-        )
-        config.releases.collect{it.josmVersion}.unique().sort().each {jv ->
-            def dv = bestPluginVersion(config, jv)
-            def key = "${jv}_Plugin-Url".toString()
-            def value = "${dv};https://raw.github.com/Gubaer/josm-scripting-plugin/for-josm-${jv}/dist/scripting.jar".toString()
-            attributes([(key):value])
-        }
-    }
-    from zipTree(configurations.rhino.asPath)
-    from zipTree(configurations.jsyntaxpane.asPath)
-    from zipTree(configurations.javaxvalidation.asPath)
 
     from("src") {
       include("**/*.dtd")
@@ -112,28 +90,9 @@ test {
     }
 }
 
-task  getJosm {
-    description = "Download a JOSM jar from the JOSM website"
-    doLast {
-        if (! file("libs").exists()) {
-            file("libs").mkdir()
-        }
-        if (!file("libs/josm.jar").exists()) {
-            println "Downloading JOSM from <${josmDownloadUrl}> ..."
-            download {
-                src josmDownloadUrl
-                dest "libs/josm.jar"
-            }
-        }
-    }
-}
-
-compileJava.dependsOn "getJosm"
-
 sourceSets {
     main {
-        java.srcDirs = ["src", "test/common"]
-        groovy.srcDirs = ["test/unit"]
+        java.srcDirs = ["src"]
         resources {
             srcDirs(file("."))
             include("LICENSE")
@@ -152,24 +111,17 @@ sourceSets {
     test {
         java.srcDirs = ["test/common"]
         groovy.srcDirs = ["test/unit"]
+        resources.srcDirs = ["test"]
     }
 }
 
-clean.doFirst {
-    delete "libs/josm.jar"
-}
-
+tasks.dist.into("$projectDir/dist")
 task deploy {
+    dependsOn dist
     doLast {
         def config = new ConfigSlurper().parse(file("releases.conf").text)
         def deployBranch = "deploy"
-        def jar = "dist/scripting.jar";
-        file("dist").mkdirs()
-        ant.copy(todir: "dist") {
-            fileset(dir : "build/libs") {
-                  include(name:"scripting.jar")
-            }
-        }
+        def jar = "$projectDir/dist/${archivesBaseName}.jar";
         Git.ensureOnBranch(deployBranch)
         Git.add(jar)
         Git.commit(jar, "commited plugin build ${currentPluginVersion(config)}")
@@ -178,10 +130,6 @@ task deploy {
         Git.push("origin", deployBranch)
         Git.pushTags()
     }
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.2'
 }
 
 class Git {
@@ -225,4 +173,3 @@ class Git {
         executeAndLog("git push --tags -f")
     }
 }
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,0 @@
-# download URL for JOSM latest
-josmDownloadUrl=http://josm.openstreetmap.de/josm-latest.jar
-# download URL for JOSM tested
-#josmDownloadUrl=http://josm.openstreetmap.de/josm-tested.jar
-#josmDownloadUrl=http://josm.openstreetmap.de/download/josm-snapshot-10659.jar
-
-# enable gradle daemon
-org.gradle.daemon=true

--- a/src/org/openstreetmap/josm/plugins/scripting/ScriptingPlugin.java
+++ b/src/org/openstreetmap/josm/plugins/scripting/ScriptingPlugin.java
@@ -227,6 +227,7 @@ public class ScriptingPlugin extends Plugin implements PreferenceKeys{
                        res));
                 return;
             }
+            mimeTypesTarget.getParentFile().mkdirs();
             try(FileOutputStream fout = new FileOutputStream(mimeTypesTarget)) {
                 byte [] buf = new byte[1024];
                 int read;


### PR DESCRIPTION
Hi @Gubaer,
I noticed that you are building your JOSM plugin with Gradle and wanted to suggest the [`gradle-josm-plugin`](https://github.com/floscher/gradle-josm-plugin) to you. It includes some quite useful tools and reduces the amount of configuration (Disclaimer: I'm the author of that plugin).

That Gradle plugin is the result of my work on the [josm-mapillary-plugin](https://github.com/JOSM/Mapillary), earlier this year I decided to make those parts of it available as a Gradle plugin, which could be reused by other JOSM plugins.

My favourite features:
* the `runJosm` task: fires up an clean instance of JOSM with only your plugin loaded (as compiled from the current source code). No JOSM installation required! And if JOSM **is** installed, it won't interfere with your installation, because a different `JOSM_HOME` directory is used. (see also `debugJosm` task, which provides remote debugging capability)
* the manifest configuration is done in a separate [`josm.manifest{}`](https://floscher.github.io/gradle-josm-plugin/groovydoc/current/index.html?org/openstreetmap/josm/gradle/plugin/config/JosmManifest.html) block, with sensible default values (e.g. `Plugin-Date`, `Plugin-Version`, `Created-By`)
* to set the JOSM version to compile against (and to use for the `runJosm` taks), simply set `josm.josmCompileVersion` to an integer version that is available for download (the strings `latest` and `tested` also work). It will automatically appear on the classpath in that version.
* with the task `minJosmVersionClasses` you can try to compile against the minimum JOSM version that your JOSM plugin is compatible with(`Plugin-Mainversion`). If it fails, you know you have to update it.
* since version `0.2.0` there's also a task `i18n-xgettext`, which extracts the strings for internationalization. For the Mapillary plugin I'm now putting that onto the `gh-pages` branch for every commit to `master`, so Transifex can auto-update the strings daily
* …

Documentation for the `gradle-josm-plugin` is available at https://github.com/floscher/gradle-josm-plugin#readme

---

Two sidenotes:
* In 0b83c5f749b6283089394f992db774cba219749a I fixed a bug, that I discovered when making these changes. The file `mime.types` could not be created, because the directory around it didn't exist.
* for the JOSM manifest you add `Built-With: gradle-4.2 groovy-2.4.11`. The `gradle-josm-plugin` adds `Gradle-Version: 4.2` and `Groovy-Version: 2.4.11` instead.