### PR TITLE
Replace Main.getLayerManager() by MainApplication.getLayerManager()

### DIFF
--- a/javascript/josm/command.js
+++ b/javascript/josm/command.js
@@ -173,8 +173,7 @@ exports.DeleteCommand.prototype.createJOSMCommand = function(layer) {
         "layer: must not be null or undefined");
     util.assert(layer instanceof OsmDataLayer,
         "layer: expected OsmDataLayer, got {0}", layer);
-    return new DeleteCommand.delete(layer, this._objs,
-        true /* alsoDeleteNodesInWay */, true /* silent */);
+    return new DeleteCommand.delete(this._objs, true /* alsoDeleteNodesInWay */, true /* silent */);
 };
 
 /**

--- a/javascript/josm/layers.js
+++ b/javascript/josm/layers.js
@@ -7,7 +7,7 @@
  */
 
 //-- imports
-var Main = org.openstreetmap.josm.Main;
+var MainApplication = org.openstreetmap.josm.gui.MainApplication;
 var OsmDataLayer = org.openstreetmap.josm.gui.layer.OsmDataLayer;
 var DataSet = org.openstreetmap.josm.data.osm.DataSet;
 var Layer = org.openstreetmap.josm.gui.layer.Layer;
@@ -25,7 +25,7 @@ var util = require("josm/util");
  */
 Object.defineProperty(exports, "length", {
     get: function() {
-        return Main.getLayerManager().getLayers().size();
+        return MainApplication.getLayerManager().getLayers().size();
     }
 });
 
@@ -50,7 +50,7 @@ Object.defineProperty(exports, "length", {
  */
 Object.defineProperty(exports, "activeLayer", {
     get: function() {
-        return Main.getLayerManager().getActiveLayer();
+        return MainApplication.getLayerManager().getActiveLayer();
     },
     set: function(value) {
         util.assert(util.isSomething(value),
@@ -66,14 +66,14 @@ Object.defineProperty(exports, "activeLayer", {
         util.assert(util.isSomething(layer),
             "Layer ''{0}'' doesn''t exist. It can''t be set as active layer.",
             value);
-        Main.getLayerManager().setActiveLayer(layer);
+        MainApplication.getLayerManager().setActiveLayer(layer);
     }
 });
 
 function getLayerByName(key) {
     key = util.trim(key).toLowerCase();
     if (exports.length == 0) return undefined;
-    var layers = Main.getLayerManager().getLayers();
+    var layers = MainApplication.getLayerManager().getLayers();
     for(var it=layers.iterator(); it.hasNext();) {
         var l = it.next();
         if (l.getName().trim().toLowerCase().equals(key)) return l;
@@ -83,7 +83,7 @@ function getLayerByName(key) {
 
 function getLayerByIndex(idx) {
     if (idx < 0 || idx >= exports.length) return undefined;
-    var layers = Main.getLayerManager().getLayers();
+    var layers = MainApplication.getLayerManager().getLayers();
     return layers.get(idx);
 }
 
@@ -148,7 +148,7 @@ exports.get = function(key) {
  */
 exports.has = function(layer) {
     if (util.isNothing(layer)) return false;
-    var layerManager = Main.getLayerManager();
+    var layerManager = MainApplication.getLayerManager();
     if (layer instanceof Layer) {
         return layerManager.getLayers().contains(layer);
     } else if (util.isString(layer)) {
@@ -192,7 +192,7 @@ exports.has = function(layer) {
 exports.add = function(obj) {
     //util.println("obj: " + obj);
     if (util.isNothing(obj)) return;
-    var layerManager = Main.getLayerManager();
+    var layerManager = MainApplication.getLayerManager();
     if (obj instanceof Layer) {
         layerManager.addLayer(obj);
     } else if (obj instanceof DataSet){
@@ -207,13 +207,13 @@ exports.add = function(obj) {
 var removeLayerByIndex = function(idx) {
     var layer = exports.get(idx);
     if (util.isNothing(layer)) return;
-    Main.getLayerManager().removeLayer(layer);
+    MainApplication.getLayerManager().removeLayer(layer);
 };
 
 var removeLayerByName = function(name) {
     var layer = exports.get(name);
     if (util.isNothing(layer)) return;
-    Main.getLayerManager().removeLayer(layer);
+    MainApplication.getLayerManager().removeLayer(layer);
 };
 
 /**

--- a/javascript/josm/mixin/JSActionMixin.js
+++ b/javascript/josm/mixin/JSActionMixin.js
@@ -324,6 +324,7 @@ function afterFromOptions(options) {
  */
 mixin.addToToolbar = function(options) {
     var Main = org.openstreetmap.josm.Main;
+    var MainApplication = org.openstreetmap.josm.gui.MainApplication;
     var ArrayList = java.util.ArrayList;
     options = options || {};
     util.assert(typeof options === "object",
@@ -332,10 +333,10 @@ mixin.addToToolbar = function(options) {
         this.putValue("toolbarId", String(options.toolbarId));
     }
 
-    Main.toolbar.register(this);
+    MainApplication.getToolbar().register(this);
     var toolbarId = this.getValue("toolbarId");
     var toolbarPrefs = new ArrayList(
-        Main.pref.getCollection("toolbar",new ArrayList()));
+        Main.pref.getList("toolbar",new ArrayList()));
 
     // The following is clumsy. We have to fiddle with preference settings
     // in order to display a toolbar entry at a specific position
@@ -353,7 +354,7 @@ mixin.addToToolbar = function(options) {
             toolbarPrefs.remove(toolbarId);
             toolbarPrefs.add(Math.min(toolbarPrefs.size(), at), toolbarId);
         }       
-        Main.pref.putCollection("toolbar", toolbarPrefs);
+        Main.pref.putList("toolbar", toolbarPrefs);
     } else if (util.isDef(after)) {
         // if we got the parameter 'after', we try to insert it after the
         // entry given as value for 'after'
@@ -363,7 +364,7 @@ mixin.addToToolbar = function(options) {
             toolbarPrefs.remove(toolbarId);
             toolbarPrefs.add(at + 1, toolbarId);
         }
-        Main.pref.putCollection("toolbar", toolbarPrefs);
+        Main.pref.putList("toolbar", toolbarPrefs);
     } else if (util.isDef(before)) {
         // if we got the parameter 'before', we try to insert it before the
         // entry given as value for 'before'
@@ -373,9 +374,9 @@ mixin.addToToolbar = function(options) {
             toolbarPrefs.remove(toolbarId);
             toolbarPrefs.add(at, toolbarId);
         }
-        Main.pref.putCollection("toolbar", toolbarPrefs);
+        Main.pref.putList("toolbar", toolbarPrefs);
     }
-    Main.toolbar.refreshToolbarControl();
+    MainApplication.getToolbar().refreshToolbarControl();
 };
 
 exports.forClass = org.openstreetmap.josm.plugins.scripting.js.JSAction;

--- a/scripts/HelloWorld.groovy
+++ b/scripts/HelloWorld.groovy
@@ -1,8 +1,9 @@
 /*
- * HelloWorld.groovy - displays the number of actually open layers 
+ * HelloWorld.groovy - displays the number of actually open layers
  */
 import javax.swing.JOptionPane
 import org.openstreetmap.josm.Main
+import org.openstreetmap.josm.gui.MainApplication
 
-def numlayers = Main.getLayerManager().getLayers().size()
+def numlayers = MainApplication.getLayerManager().getLayers().size()
 JOptionPane.showMessageDialog(Main.parent, "[Groovy] Hello World!\nYou have ${numlayers} layer(s).")

--- a/scripts/HelloWorld.js
+++ b/scripts/HelloWorld.js
@@ -1,9 +1,10 @@
 /*
-* HelloWorld.js  -  displays the number of actually open layers 
+* HelloWorld.js  -  displays the number of actually open layers
 */
 
 var JOptionPane = javax.swing.JOptionPane;
 var Main = org.openstreetmap.josm.Main;
+var MainApplication = org.openstreetmap.josm.gui.MainApplication;
 
-var numlayers = Main.getLayerManager().getLayers().size();
+var numlayers = MainApplication.getLayerManager().getLayers().size();
 JOptionPane.showMessageDialog(Main.parent, "[JavaScript] Hello World! You have " + numlayers + " layer(s).");

--- a/scripts/HelloWorld.py
+++ b/scripts/HelloWorld.py
@@ -1,8 +1,9 @@
 #
 # HelloWorld.py  - displays the number of actually open layers
-# 
+#
 from javax.swing import JOptionPane
 from org.openstreetmap.josm import Main
+from org.openstreetmap.josm import MainApplication
 
-numlayers = Main.getLayerManager().getLayers().size()	
+numlayers = MainApplication.getLayerManager().getLayers().size()
 JOptionPane.showMessageDialog(Main.parent, "[Python] Hello World! You have %s layer(s)." % numlayers)


### PR DESCRIPTION
The method has been moved and is no longer available in the old location.

At least a partial fix for #63. Maybe there are more deprecated/removed methods (see https://josm.openstreetmap.de/ticket/15310).
  