### PR TITLE
Run JS tests when building

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.openstreetmap.josm' version '0.2.1'
+    id 'org.openstreetmap.josm' version '0.3.0'
     id 'java'
     id 'groovy'
     id 'eclipse'
@@ -32,6 +32,7 @@ dependencies {
     packIntoJar group: "de.sciss", name: "jsyntaxpane", version: "1.0.0"
     packIntoJar group: 'javax.validation', name: 'validation-api', version: '1.0.0.GA'
 
+    testImplementation('org.openstreetmap.josm:josm-unittest:latest'){changing=true}
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.4.12'
 }
@@ -81,15 +82,28 @@ compileJava {
   options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation" << "-Werror"
 }
 
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 test {
     useJUnit()
     environment "JOSM_SCRIPTING_PLUGIN_HOME", project.projectDir
     scanForTestClasses = false
     include "**/AllUnitTests.class"
-    beforeTest { descriptor ->
-        logger.lifecycle("Running test: " + descriptor)
+    testLogging.events TestLogEvent.FAILED, TestLogEvent.PASSED
+}
+
+task testScriptApi (type: Test) {
+    useJUnit()
+    environment "JOSM_SCRIPTING_PLUGIN_HOME", project.projectDir
+    scanForTestClasses = false
+    include "ScriptApiTest.class"
+    testLogging {
+        events TestLogEvent.FAILED, TestLogEvent.PASSED
+        exceptionFormat = TestExceptionFormat.FULL
     }
 }
+tasks.check.dependsOn(tasks.testScriptApi)
 
 sourceSets {
     main {
@@ -110,7 +124,7 @@ sourceSets {
         }
     }
     test {
-        java.srcDirs = ["test/common"]
+        java.srcDirs = ["test/common", "test/script-api"]
         groovy.srcDirs = ["test/unit"]
         resources.srcDirs = ["test"]
     }

--- a/javascript/josm/unittest.js
+++ b/javascript/josm/unittest.js
@@ -83,6 +83,7 @@ exports.Suite.prototype.run = function() {
 	out.println("----------------------------------------------------------------------");
 	out.println(" # tests: " + numtests + " # PASS : " + numok + "  # FAIL : " + numfail);
 	out.println("----------------------------------------------------------------------");
+	return numfail;
 };
 
 exports.expectError = function(f) {

--- a/test/script-api/DataSetWrapperTest.js
+++ b/test/script-api/DataSetWrapperTest.js
@@ -285,8 +285,8 @@ suites.push(tu.suite(
 ));
 
 exports.run = function() {
-    for (var i=0; i<suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };
 

--- a/test/script-api/ScriptApiTest.java
+++ b/test/script-api/ScriptApiTest.java
@@ -1,0 +1,73 @@
+import java.awt.GraphicsEnvironment;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.util.logging.Level;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.josm.plugins.PluginException;
+import org.openstreetmap.josm.plugins.PluginInformation;
+import org.openstreetmap.josm.plugins.scripting.ScriptingPlugin;
+import org.openstreetmap.josm.plugins.scripting.js.JOSMModuleScriptProvider;
+import org.openstreetmap.josm.plugins.scripting.js.RhinoEngine;
+import org.openstreetmap.josm.plugins.scripting.ui.console.ScriptingConsole;
+import org.openstreetmap.josm.testutils.JOSMTestRules;
+import org.openstreetmap.josm.tools.Logging;
+
+public class ScriptApiTest {
+
+    @Rule
+    public JOSMTestRules rules = new JOSMTestRules().preferences().platform().projection().main();
+
+    private RhinoEngine engine;
+
+    @Before
+    public void setup() throws PluginException, MalformedURLException {
+        final String projectDirEnv = System.getenv("JOSM_SCRIPTING_PLUGIN_HOME");
+        final File projectDir = new File(projectDirEnv == null ? "." : projectDirEnv);
+
+        JOSMModuleScriptProvider.getInstance().addRepository(new File(projectDir,  "javascript/").toURI().toURL());
+        JOSMModuleScriptProvider.getInstance().addRepository(new File(projectDir,  "test/script-api/").toURI().toURL());
+        new ScriptingPlugin(new PluginInformation(new File(projectDir, "dist/scripting.jar")));
+
+        engine = RhinoEngine.getInstance();
+        engine.enterSwingThreadContext();
+
+        Logging.getLogger().setFilter(record -> record.getLevel().intValue() >= Level.WARNING.intValue());
+    }
+
+    @Test
+    public void scriptApiTestSuite() {
+        engine.evaluateOnSwingThread("require(\"suite\").fragileRun()");
+    }
+
+    @Test
+    public void commandAddTest() {
+        engine.evaluateOnSwingThread("require(\"functional/commandAddTest.js\")");
+    }
+
+    @Test
+    public void commandChangeTest() {
+        engine.evaluateOnSwingThread("require(\"functional/commandDeleteTest.js\")");
+    }
+
+    @Test
+    public void commandDeleteTest() {
+        engine.evaluateOnSwingThread("require(\"functional/commandDeleteTest.js\")");
+    }
+
+    @Test
+    public void commandUndoRedoTest() {
+        engine.evaluateOnSwingThread("require(\"functional/commandUndoRedo.js\")");
+    }
+
+    @Test
+    public void menuBarTest() {
+        engine.evaluateOnSwingThread("require(\"functional/menuBarTest.js\")");
+    }
+
+    @Test
+    public void menuTest() {
+        engine.evaluateOnSwingThread("require(\"functional/menuTest.js\")");
+    }
+}

--- a/test/script-api/josm/ChangesetMixinTest.js
+++ b/test/script-api/josm/ChangesetMixinTest.js
@@ -87,8 +87,8 @@ suites.push(suite = tu.suite("properties access",
 ));
 
 exports.run = function() {
-    for (var i=0; i< suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };
 

--- a/test/script-api/josm/DataSetMixinTest.js
+++ b/test/script-api/josm/DataSetMixinTest.js
@@ -834,7 +834,7 @@ suites.push(tu.suite("each",
 ));
 
 exports.run = function() {
-	for (var i=0; i < suites.length; i++) {
-		suites[i].run();
-	}
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };

--- a/test/script-api/josm/LatLonMixinTest.js
+++ b/test/script-api/josm/LatLonMixinTest.js
@@ -82,8 +82,7 @@ suites.push(tu.suite("make",
 ));
 
 exports.run = function() {
-    for (var i=0; i<suites.length; i++) {
-        suites[i].run();
-    }
-
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };

--- a/test/script-api/josm/NodeBuilderTest.js
+++ b/test/script-api/josm/NodeBuilderTest.js
@@ -266,8 +266,8 @@ suites.push(tu.suite("forDataSet test cases",
 ));
 
 exports.run = function() {
-    for (var i=0; i<suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };
 

--- a/test/script-api/josm/NodeMixinTest.js
+++ b/test/script-api/josm/NodeMixinTest.js
@@ -250,7 +250,7 @@ suites.push(tu.suite("setting modified flag as side effect",
 ));
 
 exports.run = function() {
-    for (var i=0; i<suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };

--- a/test/script-api/josm/OsmPrimitiveMixinTest.js
+++ b/test/script-api/josm/OsmPrimitiveMixinTest.js
@@ -381,7 +381,7 @@ suites.push(tu.suite("setting and getting tags",
 ));
 
 exports.run = function() {
-    for (var i=0; i<suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };

--- a/test/script-api/josm/RelationBuilderTest.js
+++ b/test/script-api/josm/RelationBuilderTest.js
@@ -404,8 +404,8 @@ suites.push(tu.suite("forDataSet test cases",
 
 
 exports.run = function() {
-    for (var i=0; i<suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };
 

--- a/test/script-api/josm/RelationMixinTest.js
+++ b/test/script-api/josm/RelationMixinTest.js
@@ -145,7 +145,7 @@ suites.push(tu.suite("modified flag",
 ));
 
 exports.run = function() {
-    for (var i=0; i<suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };

--- a/test/script-api/josm/UploadStrategyMixinTest.js
+++ b/test/script-api/josm/UploadStrategyMixinTest.js
@@ -103,8 +103,8 @@ suites.push(tu.suite("is()",
 ));
 
 exports.run = function() {
-    for (var i=0; i<suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };
     

--- a/test/script-api/josm/WayBuilderTest.js
+++ b/test/script-api/josm/WayBuilderTest.js
@@ -193,7 +193,7 @@ suites.push(tu.suite("forDataSet test cases",
 ));
 
 exports.run = function() {
-    for (var i=0; i<suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };

--- a/test/script-api/josm/WayMixinTest.js
+++ b/test/script-api/josm/WayMixinTest.js
@@ -136,7 +136,7 @@ suites.push(tu.suite(
 ));
 
 exports.run = function() {
-    for (var i=0; i<suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };

--- a/test/script-api/josm/commandTest.js
+++ b/test/script-api/josm/commandTest.js
@@ -100,7 +100,7 @@ suites.push(tu.suite("add",
 ));
 
 exports.run = function() {
-    for(var i=0; i < suites.length; i++) {
-        suites[i].run();
-    }
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };

--- a/test/script-api/josm/utilTest.js
+++ b/test/script-api/josm/utilTest.js
@@ -63,7 +63,7 @@ suites.push(tu.suite("josm/util - isCollection",
 ));
 
 exports.run = function() {
-	for(var i=0; i<suites.length; i++) {
-		suites[i].run();
-	}
+    return suites
+        .map(function(a) { return a.run(); })
+        .reduce(function(a, b) { return a + b; });
 };

--- a/test/script-api/suite.js
+++ b/test/script-api/suite.js
@@ -34,9 +34,9 @@ var tests = [
 ];
 
 function run() {
-    for (var i=0; i<tests.length; i++) {
-    	require(tests[i]).run();
-    }
+    return tests
+        .map(function(a) { return require(a).run() })
+        .reduce(function(a, b) { return a + b; });
 };
 
 if (typeof exports === "undefined") {
@@ -46,6 +46,12 @@ if (typeof exports === "undefined") {
     // loaded as module. Export the run function but don't
     // execute it here. 
     exports.run = run;
+    exports.fragileRun = function() {
+        var numfail = run();
+        if (numfail > 0) {
+            throw java.lang.Exception("There are " + numfail + " failing tests");
+        } else {
+            java.lang.System.out.println("All tests ran successfully! ");
+        }
+    }
 }
-
-


### PR DESCRIPTION
This automatically runs (some of) the JavaScript tests in the directory `test/script-api/` when executing `.gradlew check`.

In order for this to work I let the `run()` method of the tests and the test suites return the number of failed tests. In the file `suite.js`, these numbers are added up and an Exception is thrown when there are failing tests.

The new Java class `test/script-api/ScriptApiTest.java` is a wrapper for the JavaScript tests, which runs them in JUnit.

Running these tests in the build should allow for catching issues like #63 earlier. This PR won't build properly before #64 is merged, because the new test case complains about the removed methods in the JOSM API.